### PR TITLE
Fix sign formspec updates while used

### DIFF
--- a/signs_api/init.lua
+++ b/signs_api/init.lua
@@ -167,7 +167,7 @@ function signs_api.register_sign(mod, name, model)
 			fixed = {-model.width/2, -model.height/2, 0.5,
 					 model.width/2, model.height/2, 0.5 - model.depth},
 		},
-		groups = {choppy=2, dig_immediate=2, not_blocking_trains=1, display_api=1},
+		groups = {choppy=2, dig_immediate=2, not_blocking_trains=1, display_api=1,signs_api_lbm=1},
 		sounds = default.node_sound_defaults(),
 		display_entities = {
 			["signs:display_text"] = {
@@ -180,9 +180,6 @@ function signs_api.register_sign(mod, name, model)
 
 		},
 		on_place = display_api.on_place,
-		on_rightclick = function(pos)
-				signs_api.set_formspec(pos)
-			end,
 		on_construct = 	function(pos)
 				local ndef = minetest.registered_nodes[minetest.get_node(pos).name]
 				local meta = minetest.get_meta(pos)
@@ -224,3 +221,14 @@ end
 
 -- Text entity for all signs
 display_api.register_display_entity("signs:display_text")
+
+-- Update sign formspecs
+minetest.register_lbm({
+	label = "Update signs_api formspecs",
+	name = "signs_api:update_formspecs",
+	run_at_every_load = false,
+	nodenames = {"group:signs_api_lbm"},
+	action = function(pos)
+		signs_api.set_formspec(pos)
+	end,
+})

--- a/signs_api/init.lua
+++ b/signs_api/init.lua
@@ -167,7 +167,7 @@ function signs_api.register_sign(mod, name, model)
 			fixed = {-model.width/2, -model.height/2, 0.5,
 					 model.width/2, model.height/2, 0.5 - model.depth},
 		},
-		groups = {choppy=2, dig_immediate=2, not_blocking_trains=1, display_api=1,signs_api_lbm=1},
+		groups = {choppy=2, dig_immediate=2, not_blocking_trains=1, display_api=1,signs_api_formspec_lbm=1},
 		sounds = default.node_sound_defaults(),
 		display_entities = {
 			["signs:display_text"] = {
@@ -227,7 +227,7 @@ minetest.register_lbm({
 	label = "Update signs_api formspecs",
 	name = "signs_api:update_formspecs",
 	run_at_every_load = false,
-	nodenames = {"group:signs_api_lbm"},
+	nodenames = {"group:signs_api_formspec_lbm"},
 	action = function(pos)
 		signs_api.set_formspec(pos)
 	end,


### PR DESCRIPTION
Please read https://gitea.your-land.de/your-land/bugtracker/issues/5553

EDIT(wsor - lazy and tired of opening the link above, this from flux):
i figured out why i could't replicate this locally initially - it only happens when using the mt-mods fork of display_modpack, not the pyrollo fork. i've traced it to this commit: [1f8e99c9c5](https://github.com/mt-mods/display_modpack/commit/1f8e99c9c52afb05d7523b25e2e4fff6f236ed5f)

the issue is that when a player is looking at a node formspec, and the node formspec is modified, what the player sees is also modified. but looking at that commit above, right-clicking the sign should only modify the formspec if it needs to have that fix applied. however, i'm having this issue multiple times on certain signs, and also for new signs that were placed well after the fix was applied. something else might be modifying the sign formspec, perhaps...