### PR TITLE
Make dp_modpack game agnostic using XCompat

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -4,7 +4,7 @@ read_globals = {
 	"minetest",
 	"table",
 	"vector",
-	"default"
+	"xcompat"
 }
 
 globals = {

--- a/boards/init.lua
+++ b/boards/init.lua
@@ -33,7 +33,7 @@ local function set_formspec(pos)
 	local meta = minetest.get_meta(pos)
 	local display_text = minetest.formspec_escape(meta:get_string("display_text"))
 	meta:set_string("formspec",
-		"size[6,3.5]"..default.gui_bg..default.gui_bg_img..default.gui_slots..
+		"size[6,3.5]"..
 		"textarea[0.55,0.25;5.5,3;display_text;"..FS("Text")..";" .. display_text .. "]"..
 		"button_exit[1,2.75;2,1;ok;"..FS("Write").."]"..
 		"button[3,2.75;2,1;font;"..FS("Font").."]")
@@ -52,6 +52,8 @@ local function on_receive_fields(pos, formname, fields, player)
 	end
 end
 
+local wood_texture = xcompat.textures.wood.planks
+
 local models = {
 	black_board = {
 		depth = 1/16, width = 1, height = 1,
@@ -65,9 +67,9 @@ local models = {
 		},
 		node_fields = {
 			description = S("Black board"),
-			tiles = { "default_wood.png", "default_wood.png",
-				"default_wood.png", "default_wood.png",
-				"default_wood.png", "board_black_front.png" },
+			tiles = {wood_texture, wood_texture,
+				wood_texture, wood_texture,
+				wood_texture, "board_black_front.png"},
 			_itemframe_texture = "board_black_front.png",
 			drawtype = "nodebox",
 			node_box = {
@@ -103,9 +105,9 @@ local models = {
 		},
 		node_fields = {
 			description = S("Green board"),
-			tiles = { "default_wood.png", "default_wood.png",
-				"default_wood.png", "default_wood.png",
-				"default_wood.png", "board_green_front.png" },
+			tiles = {wood_texture, wood_texture,
+				wood_texture, wood_texture,
+				wood_texture, "board_green_front.png"},
 			drawtype = "nodebox",
 			_itemframe_texture = "board_green_front.png",
 			node_box = {
@@ -138,11 +140,13 @@ do
 end
 
 -- Recipes
+local mat = xcompat.materials
+
 minetest.register_craft(
 	{
 		output = "boards:black_board",
 		recipe = {
-			{"group:wood", "group:stone", "dye:black"},
+			{"group:wood", "group:stone", mat.dye_black},
 		}
 	})
 
@@ -150,7 +154,7 @@ minetest.register_craft(
 	{
 		output = "boards:green_board",
 		recipe = {
-			{"group:wood", "group:stone", "dye:dark_green"},
+			{"group:wood", "group:stone", mat.dye_dark_green},
 		}
 	})
 

--- a/boards/mod.conf
+++ b/boards/mod.conf
@@ -1,4 +1,4 @@
 name = boards
 title = Black boards
 description = Writable school boards using sign_api
-depends = default,signs_api
+depends = signs_api, xcompat

--- a/display_api/README.md
+++ b/display_api/README.md
@@ -4,7 +4,7 @@ This library's purpose is to ease creation of nodes with one or more displays on
 
 **Limitations**: This lib uses entities to draw display. This means display has to be vertical (and "upside up") on Minetest before version 5.0.
 
-**Dependancies**:default
+**Dependencies**: xcompat
 
 **License**: LGPLv2
 

--- a/font_api/README.md
+++ b/font_api/README.md
@@ -2,7 +2,7 @@
 
 A library for rendernig text on textures (to be used with display_api for sign creation).
 
-**Dependancies**: default
+**Dependencies**: xcompat
 
 **License**: LGPL
 

--- a/font_api/fontform.lua
+++ b/font_api/fontform.lua
@@ -98,9 +98,8 @@ local function show_font_formspec(playername)
 	table.sort(fonts)
 
 	local fs = string.format(
-		"size[4,%s]%s%s%sbutton_exit[0,%s;4,1;cancel;%s]",
-		#fonts + 0.8, default.gui_bg, default.gui_bg_img, default.gui_slots,
-		#fonts, FS("Cancel"))
+		"size[4,%s]button_exit[0,%s;4,1;cancel;%s]",
+		#fonts + 0.8, #fonts, FS("Cancel"))
 
 	for line = 1, #fonts do
 		local font = font_api.get_font(fonts[line])

--- a/ontime_clocks/README.md
+++ b/ontime_clocks/README.md
@@ -4,7 +4,7 @@ This mod provides clocks that display real ingame time.
 
 For more information, see the [forum topic](https://forum.minetest.net/viewtopic.php?t=19365) at the Minetest forums.
 
-**Dependancies**: display_api, default
+**Dependencies**: display_api, xcompat
 
 **License**: Code under LGPL, textures under CC-BY-SA
 

--- a/ontime_clocks/crafts.lua
+++ b/ontime_clocks/crafts.lua
@@ -18,11 +18,13 @@
     along with ontime_clocks.  If not, see <http://www.gnu.org/licenses/>.
 --]]
 
+local mat = xcompat.materials
+
 minetest.register_craft({
 	output = 'ontime_clocks:green_digital',
 	recipe = {
-		{'', 'dye:green', ''},
-		{'default:glass', 'default:mese_crystal', 'default:glass'},
+		{'', mat.dye_green, ''},
+		{mat.glass, mat.mese_crystal, mat.glass},
 		{'', '', ''},
 	}
 })
@@ -30,8 +32,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'ontime_clocks:red_digital',
 	recipe = {
-		{'', 'dye:red', ''},
-		{'default:glass', 'default:mese_crystal', 'default:glass'},
+		{'', mat.dye_red, ''},
+		{mat.glass, mat.mese_crystal, mat.glass},
 		{'', '', ''},
 	}
 })
@@ -39,8 +41,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'ontime_clocks:white',
 	recipe = {
-		{'default:steel_ingot', 'default:paper', 'default:steel_ingot'},
-		{'', 'default:mese_crystal', ''},
+		{mat.steel_ingot, mat.paper, mat.steel_ingot},
+		{'', mat.mese_crystal, ''},
 		{'', '', ''},
 	}
 })
@@ -48,8 +50,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'ontime_clocks:frameless_black',
 	recipe = {
-		{'default:steel_ingot', 'dye:black', 'default:steel_ingot'},
-		{'', 'default:mese_crystal', ''},
+		{mat.steel_ingot, mat.dye_black, mat.steel_ingot},
+		{'', mat.mese_crystal, ''},
 		{'', '', ''},
 	}
 })
@@ -57,8 +59,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'ontime_clocks:frameless_gold',
 	recipe = {
-		{'default:gold_ingot', '', 'default:gold_ingot'},
-		{'', 'default:mese_crystal', ''},
+		{mat.gold_ingot, '', mat.gold_ingot},
+		{'', mat.mese_crystal, ''},
 		{'', '', ''},
 	}
 })
@@ -66,8 +68,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'ontime_clocks:frameless_white',
 	recipe = {
-		{'default:steel_ingot', 'dye:white', 'default:steel_ingot'},
-		{'', 'default:mese_crystal', ''},
+		{mat.steel_ingot, mat.dye_white, mat.steel_ingot},
+		{'', mat.mese_crystal, ''},
 		{'', '', ''},
 	}
 })

--- a/ontime_clocks/mod.conf
+++ b/ontime_clocks/mod.conf
@@ -1,4 +1,4 @@
 name = ontime_clocks
 title = Ontime Clocks
 description = Clocks displaing real ingame time
-depends = default,dye,display_api
+depends = display_api, xcompat

--- a/signs/README.md
+++ b/signs/README.md
@@ -4,7 +4,7 @@ This mod provides various signs with text display. Text is locked if area is pro
 
 For more information, see the [forum topic](https://forum.minetest.net/viewtopic.php?t=19365) at the Minetest forums.
 
-**Dependancies**: default, display\_lib, font\_lib
+**Dependencies**: xcompat, display\_lib, font\_lib
 
 **License**: Code under LGPL, Textures and models under CC-BY-SA
 

--- a/signs/crafts.lua
+++ b/signs/crafts.lua
@@ -1,8 +1,10 @@
+local mat = xcompat.materials
+
 minetest.register_craft({
 	output = 'signs:wooden_right_sign',
 	recipe = {
 		{'group:wood', 'group:wood', 'group:wood'},
-		{'group:wood', 'group:wood', 'dye:black'},
+		{'group:wood', 'group:wood', mat.dye_black},
 		{'', '', ''},
 	}
 })
@@ -16,7 +18,7 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs:wooden_long_sign',
 	recipe = {
-		{'group:wood', 'dye:black',  'group:wood'},
+		{'group:wood', mat.dye_black,  'group:wood'},
 		{'group:wood', 'group:wood', 'group:wood'},
 		{'', '', ''},
 	}
@@ -31,7 +33,7 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs:wooden_sign',
 	recipe = {
-		{'', 'dye:black',  ''},
+		{'', mat.dye_black,  ''},
 		{'group:wood', 'group:wood', 'group:wood'},
 		{'group:wood', 'group:wood', 'group:wood'},
 	}
@@ -40,22 +42,22 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs:paper_poster',
 	recipe = {
-		{'default:paper', 'default:paper', 'dye:black'},
-		{'default:paper', 'default:paper', ''},
-		{'default:paper', 'default:paper', ''},
+		{mat.paper, mat.paper, mat.dye_black},
+		{mat.paper, mat.paper, ''},
+		{mat.paper, mat.paper, ''},
 	}
 })
 
 minetest.register_craft({
 	output = 'signs:label_small',
 	recipe = {
-		{'default:paper', 'dye:black'},
+		{mat.paper, mat.dye_black},
 	}
 })
 
 minetest.register_craft({
 	output = 'signs:label_medium',
 	recipe = {
-		{'default:paper', 'default:paper', 'dye:black'},
+		{mat.paper, mat.paper, mat.dye_black},
 	}
 })

--- a/signs/mod.conf
+++ b/signs/mod.conf
@@ -1,4 +1,4 @@
 name = signs
 title = Signs
 description = Basic signs and posters with text display using signs_api
-depends = default,dye,signs_api
+depends = signs_api, xcompat

--- a/signs/nodes.lua
+++ b/signs/nodes.lua
@@ -65,12 +65,12 @@ local function edit_poster(pos, node, player)
 
 	if not minetest.is_protected(pos, player:get_player_name()) then
 		fs = string.format([=[
-			size[6.5,7.5]%s%s%s
+			size[6.5,7.5]
 			field[0.5,0.7;6,1;display_text;%s;%s]
 			textarea[0.5,1.7;6,6;text;%s;%s]
 			button[1.25,7;2,1;font;%s]
 			button_exit[3.25,7;2,1;write;%s]]=],
-			default.gui_bg, default.gui_bg_img, default.gui_slots, FS("Title"),
+			FS("Title"),
 			minetest.formspec_escape(meta:get_string("display_text")),
 			FS("Text"), minetest.formspec_escape(meta:get_string("text")),
 			FS("Title font"), FS("Write"))

--- a/signs_api/README.md
+++ b/signs_api/README.md
@@ -5,7 +5,7 @@ No actual signs get registered by this mod, the signs are defined in the sign su
 
 For more information, see the [forum topic](https://forum.minetest.net/viewtopic.php?t=19365) at the Minetest forums.
 
-**Dependancies**: default, display\_lib, font\_lib
+**Dependencies**: xcompat, display\_lib, font\_lib
 
 **License**: Code under LGPL, Textures and models under CC-BY-SA
 

--- a/signs_api/init.lua
+++ b/signs_api/init.lua
@@ -67,8 +67,7 @@ function signs_api.set_formspec(pos)
 		fs = fs.."button[1,"..y..";2,1;font;"..FS("Font").."]"
 		fs = fs.."button_exit[3,"..y..";2,1;ok;"..FS("Write").."]"
 		y = y + 0.8
-		fs = "size[6,"..y.."]"..default.gui_bg..
-			default.gui_bg_img..default.gui_slots..fs
+		fs = "size[6,"..y.."]"..fs
 
 		meta:set_string("formspec", fs)
 	end
@@ -171,7 +170,7 @@ function signs_api.register_sign(mod, name, model)
 		},
 		groups = {choppy=2, dig_immediate=2, not_blocking_trains=1, display_api=1,signs_api_formspec_lbm=1},
 		is_ground_content = false,
-		sounds = default.node_sound_defaults(),
+		sounds = xcompat.sounds.node_sound_default(),
 		display_entities = {
 			["signs:display_text"] = {
 					on_display_update = font_api.on_display_update,

--- a/signs_api/mod.conf
+++ b/signs_api/mod.conf
@@ -1,4 +1,4 @@
 name = signs_api
 title = Signs API
 description = A library providing various helper functions for registereing signs with text display
-depends = default,display_api,font_api
+depends = display_api, font_api, xcompat

--- a/signs_road/README.md
+++ b/signs_road/README.md
@@ -4,7 +4,7 @@ This mod provides road signs with text display. Text is locked if area is protec
 
 For more information, see the [forum topic](https://forum.minetest.net/viewtopic.php?t=19365) at the Minetest forums.
 
-**Dependancies**: default, display\_lib, font\_lib, signs
+**Dependencies**: xcompat, display\_lib, font\_lib, signs
 
 **License**: Code under LGPL, texture under CC-BY-SA
 

--- a/signs_road/crafts.lua
+++ b/signs_road/crafts.lua
@@ -19,13 +19,15 @@
     along with signs_road.  If not, see <http://www.gnu.org/licenses/>.
 --]]
 
+local mat = xcompat.materials
+
 -- Standard rectangle signs
 
 minetest.register_craft({
 	output = 'signs_road:white_sign 2',
 	recipe = {
-		{'dye:white', 'dye:black', ''},
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{mat.dye_white, mat.dye_black, ''},
+		{mat.steel_ingot, mat.steel_ingot, mat.steel_ingot},
 		{'', '', ''},
 	}
 })
@@ -33,8 +35,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs_road:blue_sign 2',
 	recipe = {
-		{'dye:blue', 'dye:white', ''},
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{mat.dye_blue, mat.dye_white, ''},
+		{mat.steel_ingot, mat.steel_ingot, mat.steel_ingot},
 		{'', '', ''},
 	}
 })
@@ -42,8 +44,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs_road:green_sign 2',
 	recipe = {
-		{'dye:green', 'dye:white', ''},
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{mat.dye_green, mat.dye_white, ''},
+		{mat.steel_ingot, mat.steel_ingot, mat.steel_ingot},
 		{'', '', ''},
 	}
 })
@@ -51,8 +53,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs_road:yellow_sign 2',
 	recipe = {
-		{'dye:yellow', 'dye:black', ''},
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{mat.dye_yellow, mat.dye_black, ''},
+		{mat.steel_ingot, mat.steel_ingot, mat.steel_ingot},
 		{'', '', ''},
 	}
 })
@@ -60,8 +62,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs_road:red_sign 2',
 	recipe = {
-		{'dye:red', 'dye:white', ''},
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{mat.dye_red, mat.dye_white, ''},
+		{mat.steel_ingot, mat.steel_ingot, mat.steel_ingot},
 		{'', '', ''},
 	}
 })
@@ -71,8 +73,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs_road:black_right_sign 2',
 	recipe = {
-		{'dye:black', 'dye:white', 'default:steel_ingot'},
-		{'default:steel_ingot', 'default:steel_ingot', ''},
+		{mat.dye_black, mat.dye_white, mat.steel_ingot},
+		{mat.steel_ingot, mat.steel_ingot, ''},
 		{'', '', ''},
 	}
 })
@@ -80,8 +82,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs_road:white_right_sign 2',
 	recipe = {
-		{'dye:white', 'dye:black', 'default:steel_ingot'},
-		{'default:steel_ingot', 'default:steel_ingot', ''},
+		{mat.dye_white, mat.dye_black, mat.steel_ingot},
+		{mat.steel_ingot, mat.steel_ingot, ''},
 		{'', '', ''},
 	}
 })
@@ -89,8 +91,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs_road:blue_right_sign 2',
 	recipe = {
-		{'dye:blue', 'dye:white', 'default:steel_ingot'},
-		{'default:steel_ingot', 'default:steel_ingot', ''},
+		{mat.dye_blue, mat.dye_white, mat.steel_ingot},
+		{mat.steel_ingot, mat.steel_ingot, ''},
 		{'', '', ''},
 	}
 })
@@ -98,8 +100,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs_road:green_right_sign 2',
 	recipe = {
-		{'dye:green', 'dye:white', 'default:steel_ingot'},
-		{'default:steel_ingot', 'default:steel_ingot', ''},
+		{mat.dye_green, mat.dye_white, mat.steel_ingot},
+		{mat.steel_ingot, mat.steel_ingot, ''},
 		{'', '', ''},
 	}
 })
@@ -107,8 +109,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs_road:yellow_right_sign 2',
 	recipe = {
-		{'dye:yellow', 'dye:black', 'default:steel_ingot'},
-		{'default:steel_ingot', 'default:steel_ingot', ''},
+		{mat.dye_yellow, mat.dye_black, mat.steel_ingot},
+		{mat.steel_ingot, mat.steel_ingot, ''},
 		{'', '', ''},
 	}
 })
@@ -116,8 +118,8 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs_road:red_right_sign 2',
 	recipe = {
-		{'dye:red', 'dye:white', 'default:steel_ingot'},
-		{'default:steel_ingot', 'default:steel_ingot', ''},
+		{mat.dye_red, mat.dye_white, mat.steel_ingot},
+		{mat.steel_ingot, mat.steel_ingot, ''},
 		{'', '', ''},
 	}
 })
@@ -179,17 +181,17 @@ minetest.register_craft({
 minetest.register_craft({
 	output = 'signs_road:blue_street_sign 4',
 	recipe = {
-		{'dye:blue', 'dye:white', 'dye:blue'},
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{mat.dye_blue, mat.dye_white, mat.dye_blue},
+		{mat.steel_ingot, mat.steel_ingot, mat.steel_ingot},
+		{mat.steel_ingot, mat.steel_ingot, mat.steel_ingot},
 	}
 })
 
 minetest.register_craft({
 	output = 'signs_road:red_street_sign 2',
 	recipe = {
-		{'dye:white', 'dye:red', 'dye:black'},
-		{'default:steel_ingot', 'default:steel_ingot', 'default:steel_ingot'},
+		{mat.dye_white, mat.dye_red, mat.dye_black},
+		{mat.steel_ingot, mat.steel_ingot, mat.steel_ingot},
 		{'', '', ''},
 	}
 })

--- a/signs_road/mod.conf
+++ b/signs_road/mod.conf
@@ -1,4 +1,4 @@
 name = signs_road
 title = Signs Road
 description = Various road signs with text display using signs_api
-depends = default,dye,signs_api
+depends = signs_api, xcompat

--- a/steles/README.md
+++ b/steles/README.md
@@ -4,7 +4,7 @@ This mod provides stone steles with text display. Text is locked if area is prot
 
 For more information, see the [forum topic](https://forum.minetest.net/viewtopic.php?t=19365) at the Minetest forums.
 
-**Dependancies**: default, display\_lib, font\_lib, technic?
+**Dependencies**: xcompat, display\_lib, font\_lib, technic?
 
 (Technic adds marble and granite steles)
 

--- a/steles/config.lua
+++ b/steles/config.lua
@@ -23,7 +23,7 @@ local mat = xcompat.materials
 
 steles.materials = {
 	mat.stone,
-	'default:sandstone', -- not in xcompat
+	mat.sandstone,
 	mat.desert_stone,
 	'technic:marble',
 	'technic:granite',

--- a/steles/config.lua
+++ b/steles/config.lua
@@ -19,11 +19,12 @@
 --]]
 
 local S = steles.S
+local mat = xcompat.materials
 
 steles.materials = {
-	'default:stone',
-	'default:sandstone',
-	'default:desert_stone',
+	mat.stone,
+	'default:sandstone', -- not in xcompat
+	mat.desert_stone,
 	'technic:marble',
 	'technic:granite',
 }

--- a/steles/crafts.lua
+++ b/steles/crafts.lua
@@ -25,7 +25,7 @@ for _, material in ipairs(steles.materials) do
 		output = 'steles:'..parts[2]..'_stele 4',
 		recipe = {
 			{'', material, ''},
-			{'', 'dye:black', ''},
+			{'', xcompat.materials.dye_black, ''},
 			{material, material, material},
 		}
 	})

--- a/steles/mod.conf
+++ b/steles/mod.conf
@@ -1,5 +1,5 @@
 name = steles
 title = Steles
 description = Stone steles with text display on them
-depends = default,display_api,font_api
+depends = display_api, font_api, xcompat
 optional_depends = technic

--- a/steles/nodes.lua
+++ b/steles/nodes.lua
@@ -36,13 +36,11 @@ for i, material in ipairs(steles.materials) do
 			local meta = minetest.get_meta(pos)
 			local display_text = minetest.formspec_escape(meta:get_string("display_text"))
 			meta:set_string("formspec", string.format([=[
-				size[6,4]%s%s%s
+				size[6,4]
 				textarea[0.5,0.7;5.5,2;display_text;%s;%s]
 				button[1,3;2,1;font;%s]
 				button_exit[3,3;2,1;ok;%s]]=],
-				default.gui_bg, default.gui_bg_img, default.gui_slots,
-				FS("Displayed text (3 lines max)"),
-				display_text,
+				FS("Displayed text (3 lines max)"), display_text,
 				FS("Font"), FS("Write")))
 		end
 


### PR DESCRIPTION
Closes #13

- Remove mtg specific formspec stuff
- Switch to game agnostic crafting ingredients
- Switch to game agnostic sounds
- Use game agnostic wood textures

TBD:
- [x] [`xcompat.materials.sandstone`](https://github.com/mt-mods/xcompat/pull/13) doesn't exist yet - wsor will do this
- [x] [xcompat doesn't depend on `mcl_core`](https://github.com/mt-mods/xcompat/pull/12), needs to be fixed to get some recipes working

![image](https://github.com/mt-mods/display_modpack/assets/89982526/021d40b2-7cd1-4ce6-9142-c94ccf5751e9)
