### PR TITLE
Fix visible color escape sequences when selecting text of posters

### DIFF
--- a/signs/nodes.lua
+++ b/signs/nodes.lua
@@ -43,8 +43,7 @@ local function display_poster(pos, node, player)
 		style_type[textarea;textcolor=#111]
 		textarea[0.3,1.5;7,8;;%s;]]=],
 		titletexture,
-		minetest.colorize("#111",
-			minetest.formspec_escape(meta:get_string("text"))))
+		minetest.formspec_escape(meta:get_string("text")))
 
 	if minetest.is_protected(pos, player:get_player_name()) then
 		fs = string.format("%sbutton_exit[2.5,8;2,1;ok;%s]", fs, FS("Close"))


### PR DESCRIPTION
Doesn't happen anymore:
![image](https://github.com/mt-mods/display_modpack/assets/89982526/227f9546-fdac-40a5-a012-dcfb971f62c5)

Text is still rendered in this nice light-grey due to textarea styling.