### PR TITLE
Convert CR(LF)s to LFs

### DIFF
--- a/signs_api/init.lua
+++ b/signs_api/init.lua
@@ -28,6 +28,8 @@ local FS = function(...) return minetest.formspec_escape(S(...)) end
 
 function signs_api.set_display_text(pos, text, font)
 	local meta = minetest.get_meta(pos)
+	-- Fix pasting from Windows: CR instead of LF
+	text = string.gsub(text, "\r\n?", "\n")
 	meta:set_string("display_text", text)
 	if text and text ~= "" then
 		meta:set_string("infotext", "\""..text.."\"")


### PR DESCRIPTION
Windows clients paste texts with line breaks as CR (not CRLF). It's unknown whether this is the problem with copying the texts from Minetest or pasting them. This PR fixes this by converting every CR(LF) into LF on receiving fields.

This PR is ready for review.

<details>
<summary>Signs rendered with CRs</summary>

* Left: Display Modpack
* Right: Signs lib (mt-mods/signs_lib#32)

![screenshot_20240805_110018](https://github.com/user-attachments/assets/1dd4f4b1-d354-4728-8d93-75392f32e696)
</details>